### PR TITLE
CONFIG: SETI-3543 Set cookies for requests to Jenkins

### DIFF
--- a/lib/jenkins_api_client/client.rb
+++ b/lib/jenkins_api_client/client.rb
@@ -354,6 +354,12 @@ module JenkinsApi
       @jenkins_version = response.headers['X-Jenkins']
       @hudson_version = response.headers['X-Hudson']
 
+      # CVE-2019-10384: Retrieve SESSIONID from server response if not yet done
+      unless (@cookies && @cookies.include?('JSESSIONID'))
+        server_cookies = response.headers['Set-Cookie'].map { |cookie| cookie.split(';')[0] }.join(';')
+        @cookies = "#{@cookies};#{server_cookies}"
+      end
+
       return response
     end
     protected :make_http_request


### PR DESCRIPTION
SECURITY-626: "Scripts that obtain a crumb using the /crumbIssuer/api URL
will now fail to perform actions protected from CSRF unless
the scripts retain the web session ID in subsequent requests"